### PR TITLE
Beans on Toast

### DIFF
--- a/solution.R
+++ b/solution.R
@@ -11,15 +11,15 @@ print(paste0('---> R Script Start ', t0))
 print('---> initial data set up')
 
 # instrument data
-df_bonds <- read_csv("data/data_bonds.csv") %>%
+df_bonds <- read_csv("data_bonds.csv") %>%
   mutate(datestamp = as_date(datestamp))
 
 # albi data
-df_albi <- read_csv("data/data_albi.csv") %>%
+df_albi <- read_csv("data_albi.csv") %>%
   mutate(datestamp = as_date(datestamp))
 
 # macro data
-df_macro <- read_csv("data/data_macro.csv") %>%
+df_macro <- read_csv("data_macro.csv") %>%
   mutate(datestamp = as_date(datestamp))
 
 
@@ -44,11 +44,13 @@ df_signals <- df_bonds %>%
 
 
 # parameters for optimisation - in this sample solution we use a momentum lookback strategy
-n_days <- 10
+n_days <- 100
 prev_weights <- rep(0.1, 10)
 p_active_md <- 1.3 # this can be set to your own limit, as long as the portfolio is capped at 1.5 on any given day
 weight_bounds <- c(0.0, 0.2)
 weight_matrix <- tibble()
+a = 0.6
+b = 1 - a
 
 # Signal & Weight Generation ----
 
@@ -92,7 +94,14 @@ for(i in 1:nrow(df_signals)){
     group_by(bond_code) %>% 
     mutate(md_per_conv = rollmeanr(return, n_days,na.pad = TRUE)*convexity/modified_duration) %>% 
     left_join(df_train_macro, by = "datestamp") %>% 
-    mutate(signal = md_per_conv*100 - top40_return/10 + comdty_fut/100)
+    mutate(
+      steepness = us_10y - us_2y,
+      sd_md = scale(modified_duration),
+      sd_steepness = scale(steepness),
+      signal = a*(sd_md*sd_steepness) + b*(sd_md+sd_steepness)
+    )
+  
+  df_train_bonds$signal[is.na(df_train_bonds$signal)] <- 0
   
   df_train_bonds_current <- 
     df_train_bonds %>% 
@@ -114,6 +123,7 @@ for(i in 1:nrow(df_signals)){
   turnover <- sum(abs(w - prev_weights))
   
   # Objective: maximise signal, but penalise excess turnover only
+  # print(signals)
   objective <- Maximize(t(signals) %*% w - turnover_lambda * turnover)
   
   # Constraints

--- a/solution.R
+++ b/solution.R
@@ -11,15 +11,15 @@ print(paste0('---> R Script Start ', t0))
 print('---> initial data set up')
 
 # instrument data
-df_bonds <- read_csv("data_bonds.csv") %>%
+df_bonds <- read_csv("data/data_bonds.csv") %>%
   mutate(datestamp = as_date(datestamp))
 
 # albi data
-df_albi <- read_csv("data_albi.csv") %>%
+df_albi <- read_csv("data/data_albi.csv") %>%
   mutate(datestamp = as_date(datestamp))
 
 # macro data
-df_macro <- read_csv("data_macro.csv") %>%
+df_macro <- read_csv("data/data_macro.csv") %>%
   mutate(datestamp = as_date(datestamp))
 
 
@@ -241,3 +241,4 @@ elapsed <- as.numeric(difftime(t1, t0, units = "secs"))
 
 cat(sprintf("---> R Script End %s\n", t1))
 cat(sprintf("---> Total time taken %02d:%02d\n", floor(elapsed / 60), round(elapsed %% 60)))
+


### PR DESCRIPTION
Members: Timothy Kelebeng & Tshireletso Mokobe

We first scaled the modified_duration and steepness to standardize their magnitudes. The trading signal for each bond was then constructed as:

signal=0.6×(scaled_md×scaled_steepness)+0.4×(scaled_md+scaled_steepness)

This formulation combines both the interaction of the two features and their additive contribution. A greater value of steepness points to a reduction in future yields and increasing prices of long-term bonds. Modified duration is larger for long-term bonds. This strategy favours holding long term bond if duration and steepness are larger. If steepness is negative, it favours short-term bonds. 

The shortfall in these features is that they favour longer-term bonds even when duration and steepness point towards selecting short-term bonds; when steepness is small but positive.

Additionally, we set the rolling lookback window (n_days) to 100 to smooth short-term noise while preserving recent trends in returns.
